### PR TITLE
Fix for whitespace in comma-separated color lists

### DIFF
--- a/src/lines/src/index.js
+++ b/src/lines/src/index.js
@@ -37,7 +37,7 @@ registerPaint(
 
       const sqrtArea = Math.floor(Math.sqrt(Math.pow(w, 2) + Math.pow(h, 2)))
       const saveArea = sqrtArea * 2
-      const colorLines = colors.split(',').map(color => color)
+      const colorLines = colors.split(',').map(color => color.trim())
       const maxColors = colorLines.length
       let indexColor = 0
 


### PR DESCRIPTION
Some browsers trim whitespace from color values passed to `Canvas.fillStyle=`, but Safari doesn't.